### PR TITLE
Improve the way metric names and descriptions are set

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ A module that gathers and exposes Prometheus metrics.
 
 * [metrics](#module_metrics)
     * _static_
-        * [.toSeconds(ms)](#module_metrics.toSeconds) ⇒ <code>Number</code>
         * [.initExpress(context)](#module_metrics.initExpress) ⇒ <code>Object</code>
         * [.startServer(context, port)](#module_metrics.startServer)
         * [.markCardInsert(card)](#module_metrics.markCardInsert)
@@ -57,21 +56,6 @@ A module that gathers and exposes Prometheus metrics.
         * [~actorFromContext(context)](#module_metrics..actorFromContext) ⇒ <code>String</code>
         * [~getAsyncMeasureFn(prefix)](#module_metrics..getAsyncMeasureFn) ⇒ <code>Any</code>
 
-<a name="module_metrics.toSeconds"></a>
-
-### metrics.toSeconds(ms) ⇒ <code>Number</code>
-**Kind**: static method of [<code>metrics</code>](#module_metrics)  
-**Summary**: Convert milliseconds to seconds  
-**Returns**: <code>Number</code> - seconds with fixed point notation of 4  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| ms | <code>Number</code> | milliseconds |
-
-**Example**  
-```js
-const seconds = toSeconds(ms)
-```
 <a name="module_metrics.initExpress"></a>
 
 ### metrics.initExpress(context) ⇒ <code>Object</code>

--- a/lib/descriptions.js
+++ b/lib/descriptions.js
@@ -1,0 +1,257 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+const {
+	metrics
+} = require('@balena/node-metrics-gatherer')
+const utils = require('./utils')
+
+/**
+ * A module that gathers and exposes Prometheus metrics.
+ *
+ * @module metrics
+ */
+
+// Define histogram buckets
+const latencyBuckets = metrics.client.exponentialBuckets(4, Math.SQRT2, 28).map((ms) => {
+	return utils.toSeconds(ms)
+})
+
+const queryLatencyBuckets = metrics.client.exponentialBuckets(1, Math.SQRT2, 28).map((ms) => {
+	return utils.toSeconds(ms)
+})
+
+// Metric names
+exports.names = {
+	CARD_UPSERT_TOTAL: 'jf_card_upsert_total',
+	CARD_INSERT_TOTAL: 'jf_card_insert_total',
+	CARD_READ_TOTAL: 'jf_card_read_total',
+	MIRROR_TOTAL: 'jf_mirror_total',
+	MIRROR_DURATION: 'jf_mirror_duration_seconds',
+	MIRROR_FAILURE_TOTAL: 'jf_mirror_failure_total',
+	WORKER_SATURATION: 'jf_worker_saturation',
+	WORKER_JOB_DURATION: 'jf_worker_job_duration_seconds',
+	WORKER_CONCURRENCY: 'jf_worker_concurrency',
+	WORKER_ACTION_REQUEST_TOTAL: 'jf_worker_action_request_total',
+	BACK_SYNC_CARD_TOTAL: 'jf_back_sync_total',
+	TRANSLATE_TOTAL: 'jf_translate_total',
+	TRANSLATE_DURATION: 'jf_translate_duration_seconds',
+
+	HTTP_QUERY_DURATION: 'jf_http_api_query_duration_seconds',
+	HTTP_TYPE_DURATION: 'jf_http_api_type_duration_seconds',
+	HTTP_ID_DURATION: 'jf_http_api_id_duration_seconds',
+	HTTP_SLUG_DURATION: 'jf_http_api_slug_duration_seconds',
+	HTTP_ACTION_DURATION: 'jf_http_api_action_duration_seconds',
+	HTTP_WHOAMI_DURATION: 'jf_http_whoami_query_duration_seconds',
+
+	HTTP_QUERY_TOTAL: 'jf_http_api_query_total',
+	HTTP_TYPE_TOTAL: 'jf_http_api_type_total',
+	HTTP_ID_TOTAL: 'jf_http_api_id_total',
+	HTTP_SLUG_TOTAL: 'jf_http_api_slug_total',
+	HTTP_ACTION_TOTAL: 'jf_http_api_action_total',
+	HTTP_WHOAMI_TOTAL: 'jf_http_whoami_query_total',
+
+	HTTP_QUERY_FAILURE_TOTAL: 'jf_http_api_query_failure_total',
+	HTTP_TYPE_FAILURE_TOTAL: 'jf_http_api_type_failure_total',
+	HTTP_ID_FAILURE_TOTAL: 'jf_http_api_id_failure_total',
+	HTTP_SLUG_FAILURE_TOTAL: 'jf_http_api_slug_failure_total',
+	HTTP_ACTION_FAILURE_TOTAL: 'jf_http_api_action_failure_total',
+	HTTP_WHOAMI_FAILURE_TOTAL: 'jf_http_whoami_query_failure_total',
+
+	SQL_GEN_DURATION: 'jf_sql_gen_duration_seconds',
+	QUERY_DURATION: 'jf_query_duration_seconds',
+
+	STREAMS_SATURATION: 'jf_streams_saturation',
+	STREAMS_LINK_QUERY_TOTAL: 'jf_streams_link_query_total',
+	STREAMS_ERROR_TOTAL: 'jf_streams_error_total'
+}
+
+// Define counters
+const counters = [
+	{
+		name: exports.names.CARD_UPSERT_TOTAL,
+		description: 'number of cards upserted'
+	},
+	{
+		name: exports.names.CARD_INSERT_TOTAL,
+		description: 'number of cards inserted'
+	},
+	{
+		name: exports.names.CARD_READ_TOTAL,
+		description: 'number of cards read from database/cache'
+	},
+	{
+		name: exports.names.MIRROR_TOTAL,
+		description: 'number of mirror calls'
+	},
+	{
+		name: exports.names.MIRROR_FAILURE_TOTAL,
+		description: 'number of mirror call failures'
+	},
+	{
+		name: exports.names.WORKER_ACTION_REQUEST_TOTAL,
+		description: 'number of received action requests'
+	},
+	{
+		name: exports.names.TRANSLATE_TOTAL,
+		description: 'number of translate calls'
+	},
+	{
+		name: exports.names.HTTP_QUERY_TOTAL,
+		description: 'number of /query requests'
+	},
+	{
+		name: exports.names.HTTP_TYPE_TOTAL,
+		description: 'number of /type requests'
+	},
+	{
+		name: exports.names.HTTP_ID_TOTAL,
+		description: 'number of /id requests'
+	},
+	{
+		name: exports.names.HTTP_SLUG_TOTAL,
+		description: 'number of /slug requests'
+	},
+	{
+		name: exports.names.HTTP_ACTION_TOTAL,
+		description: 'number of /action requests'
+	},
+	{
+		name: exports.names.HTTP_WHOAMI_TOTAL,
+		description: 'number of /whoami requests'
+	},
+	{
+		name: exports.names.HTTP_QUERY_FAILURE_TOTAL,
+		description: 'number of /query request failures'
+	},
+	{
+		name: exports.names.HTTP_TYPE_FAILURE_TOTAL,
+		description: 'number of /type request failures'
+	},
+	{
+		name: exports.names.HTTP_ID_FAILURE_TOTAL,
+		description: 'number of /id request failures'
+	},
+	{
+		name: exports.names.HTTP_SLUG_FAILURE_TOTAL,
+		description: 'number of /slug request failures'
+	},
+	{
+		name: exports.names.HTTP_ACTION_FAILURE_TOTAL,
+		description: 'number of /action request failures'
+	},
+	{
+		name: exports.names.HTTP_WHOAMI_FAILURE_TOTAL,
+		description: 'number of /whoami request failures'
+	},
+	{
+		name: exports.names.STREAMS_LINK_QUERY_TOTAL,
+		description: 'number of times streams query links'
+	},
+	{
+		name: exports.names.STREAMS_ERROR_TOTAL,
+		description: 'number of stream errors'
+	}
+]
+
+// Define gauges
+const gauges = [
+	{
+		name: exports.names.WORKER_SATURATION,
+		description: 'number of jobs being processed in worker queues'
+	},
+	{
+		name: exports.names.WORKER_CONCURRENCY,
+		description: 'number of jobs worker queues can process concurrently'
+	},
+	{
+		name: exports.names.STREAMS_SATURATION,
+		description: 'number of streams open'
+	}
+]
+
+// Define histograms
+const histograms = [
+	{
+		name: exports.names.HTTP_QUERY_DURATION,
+		description: 'histogram of durations taken to process /query requests in seconds',
+		buckets: latencyBuckets
+	},
+	{
+		name: exports.names.HTTP_TYPE_DURATION,
+		description: 'histogram of durations taken to process /type requests in seconds',
+		buckets: latencyBuckets
+	},
+	{
+		name: exports.names.HTTP_ID_DURATION,
+		description: 'histogram of durations taken to process /id requests in seconds',
+		buckets: latencyBuckets
+	},
+	{
+		name: exports.names.HTTP_SLUG_DURATION,
+		description: 'histogram of durations taken to process /slug requests in seconds',
+		buckets: latencyBuckets
+	},
+	{
+		name: exports.names.HTTP_WHOAMI_DURATION,
+		description: 'histogram of durations taken to process /whoami requests in seconds',
+		buckets: latencyBuckets
+	},
+	{
+		name: exports.names.MIRROR_DURATION,
+		description: 'histogram of durations taken to make mirror calls in seconds',
+		buckets: latencyBuckets
+	},
+	{
+		name: exports.names.TRANSLATE_DURATION,
+		description: 'histogram of durations taken to run translate calls in seconds',
+		buckets: latencyBuckets
+	},
+	{
+		name: exports.names.WORKER_JOB_DURATION,
+		description: 'histogram of durations taken to complete worker jobs in seconds',
+		buckets: latencyBuckets
+	},
+	{
+		name: exports.names.SQL_GEN_DURATION,
+		description: 'histogram of durations taken to generate sql with jsonschema2sql',
+		buckets: queryLatencyBuckets
+	},
+	{
+		name: exports.names.QUERY_DURATION,
+		description: 'histogram of durations taken to query the database',
+		buckets: queryLatencyBuckets
+	}
+]
+
+/**
+ * @summary Set descriptions for each metric
+ * @function
+ *
+ * @example
+ * describe()
+ */
+exports.describe = () => {
+	counters.forEach((counter) => {
+		if (!metrics.meta[counter.name]) {
+			metrics.describe.counter(counter.name, counter.description)
+		}
+	})
+
+	gauges.forEach((gauge) => {
+		if (!metrics.meta[gauge.name]) {
+			metrics.describe.counter(gauge.name, gauge.description)
+		}
+	})
+
+	histograms.forEach((histogram) => {
+		if (!metrics.meta[histogram.name]) {
+			metrics.describe.histogram(histogram.name, histogram.description, {
+				buckets: histogram.buckets
+			})
+		}
+	})
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,165 +12,14 @@ const logger = require('@balena/jellyfish-logger').getLogger(__filename)
 const {
 	metrics
 } = require('@balena/node-metrics-gatherer')
+const descriptions = require('./descriptions')
+const utils = require('./utils')
 
 /**
  * A module that gathers and exposes Prometheus metrics.
  *
  * @module metrics
  */
-
-// Prometheus metric names
-const metricNames = {
-	CARD_UPSERT_TOTAL: 'jf_card_upsert_total',
-	CARD_INSERT_TOTAL: 'jf_card_insert_total',
-	CARD_READ_TOTAL: 'jf_card_read_total',
-	MIRROR_TOTAL: 'jf_mirror_total',
-	MIRROR_DURATION: 'jf_mirror_duration_seconds',
-	MIRROR_FAILURE_TOTAL: 'jf_mirror_failure_total',
-	WORKER_SATURATION: 'jf_worker_saturation',
-	WORKER_JOB_DURATION: 'jf_worker_job_duration_seconds',
-	WORKER_CONCURRENCY: 'jf_worker_concurrency',
-	WORKER_ACTION_REQUEST_TOTAL: 'jf_worker_action_request_total',
-	BACK_SYNC_CARD_TOTAL: 'jf_back_sync_total',
-	TRANSLATE_TOTAL: 'jf_translate_total',
-	TRANSLATE_DURATION: 'jf_translate_duration_seconds',
-
-	HTTP_QUERY_DURATION: 'jf_http_api_query_duration_seconds',
-	HTTP_TYPE_DURATION: 'jf_http_api_type_duration_seconds',
-	HTTP_ID_DURATION: 'jf_http_api_id_duration_seconds',
-	HTTP_SLUG_DURATION: 'jf_http_api_slug_duration_seconds',
-	HTTP_ACTION_DURATION: 'jf_http_api_action_duration_seconds',
-	HTTP_WHOAMI_DURATION: 'jf_http_whoami_query_duration_seconds',
-
-	HTTP_QUERY_TOTAL: 'jf_http_api_query_total',
-	HTTP_TYPE_TOTAL: 'jf_http_api_type_total',
-	HTTP_ID_TOTAL: 'jf_http_api_id_total',
-	HTTP_SLUG_TOTAL: 'jf_http_api_slug_total',
-	HTTP_ACTION_TOTAL: 'jf_http_api_action_total',
-	HTTP_WHOAMI_TOTAL: 'jf_http_whoami_query_total',
-
-	HTTP_QUERY_FAILURE_TOTAL: 'jf_http_api_query_failure_total',
-	HTTP_TYPE_FAILURE_TOTAL: 'jf_http_api_type_failure_total',
-	HTTP_ID_FAILURE_TOTAL: 'jf_http_api_id_failure_total',
-	HTTP_SLUG_FAILURE_TOTAL: 'jf_http_api_slug_failure_total',
-	HTTP_ACTION_FAILURE_TOTAL: 'jf_http_api_action_failure_total',
-	HTTP_WHOAMI_FAILURE_TOTAL: 'jf_http_whoami_query_failure_total',
-
-	SQL_GEN_DURATION: 'jf_sql_gen_duration_seconds',
-	QUERY_DURATION: 'jf_query_duration_seconds',
-
-	STREAMS_SATURATION: 'jf_streams_saturation',
-	STREAMS_LINK_QUERY_TOTAL: 'jf_streams_link_query_total',
-	STREAMS_ERROR_TOTAL: 'jf_streams_error_total'
-}
-
-/**
- * @summary Convert milliseconds to seconds
- * @function
- *
- * @param {Number} ms - milliseconds
- * @returns {Number} seconds with fixed point notation of 4
- *
- * @example
- * const seconds = toSeconds(ms)
- */
-exports.toSeconds = (ms) => {
-	return Number((ms / 1000).toFixed(4))
-}
-
-// Describe each metric
-const latencyBuckets = metrics.client.exponentialBuckets(4, Math.SQRT2, 28).map((ms) => {
-	return exports.toSeconds(ms)
-})
-
-const queryLatencyBuckets = metrics.client.exponentialBuckets(1, Math.SQRT2, 28).map((ms) => {
-	return exports.toSeconds(ms)
-})
-
-metrics.describe.counter(metricNames.CARD_UPSERT_TOTAL, 'number of cards upserted')
-metrics.describe.counter(metricNames.CARD_INSERT_TOTAL, 'number of cards inserted')
-metrics.describe.counter(metricNames.CARD_READ_TOTAL, 'number of cards read from database/cache')
-metrics.describe.counter(metricNames.MIRROR_TOTAL, 'number of mirror calls')
-metrics.describe.counter(metricNames.MIRROR_FAILURE_TOTAL, 'number of mirror call failures')
-metrics.describe.gauge(metricNames.WORKER_SATURATION, 'number of jobs being processed in worker queues')
-metrics.describe.gauge(metricNames.WORKER_CONCURRENCY, 'number of jobs worker queues can process concurrently')
-metrics.describe.counter(metricNames.WORKER_ACTION_REQUEST_TOTAL, 'number of received action requests')
-metrics.describe.counter(metricNames.TRANSLATE_TOTAL, 'number of translate calls')
-metrics.describe.counter(metricNames.HTTP_QUERY_TOTAL, 'number of /query requests')
-metrics.describe.counter(metricNames.HTTP_TYPE_TOTAL, 'number of /type requests')
-metrics.describe.counter(metricNames.HTTP_ID_TOTAL, 'number of /id requests')
-metrics.describe.counter(metricNames.HTTP_SLUG_TOTAL, 'number of /slug requests')
-metrics.describe.counter(metricNames.HTTP_ACTION_TOTAL, 'number of /action requests')
-metrics.describe.counter(metricNames.HTTP_WHOAMI_TOTAL, 'number of /whoami requests')
-metrics.describe.counter(metricNames.HTTP_QUERY_FAILURE_TOTAL, 'number of /query request failures')
-metrics.describe.counter(metricNames.HTTP_TYPE_FAILURE_TOTAL, 'number of /type request failures')
-metrics.describe.counter(metricNames.HTTP_ID_FAILURE_TOTAL, 'number of /id request failures')
-metrics.describe.counter(metricNames.HTTP_SLUG_FAILURE_TOTAL, 'number of /slug request failures')
-metrics.describe.counter(metricNames.HTTP_ACTION_FAILURE_TOTAL, 'number of /action request failures')
-metrics.describe.counter(metricNames.HTTP_WHOAMI_FAILURE_TOTAL, 'number of /whoami request failures')
-metrics.describe.gauge(metricNames.STREAMS_SATURATION, 'number of streams open')
-metrics.describe.counter(metricNames.STREAMS_LINK_QUERY_TOTAL, 'number of times streams query links')
-metrics.describe.counter(metricNames.STREAMS_ERROR_TOTAL, 'number of stream errors')
-
-metrics.describe.histogram(metricNames.HTTP_QUERY_DURATION,
-	'histogram of durations taken to process /query requests in seconds',
-	{
-		buckets: latencyBuckets
-	})
-
-metrics.describe.histogram(metricNames.HTTP_TYPE_DURATION,
-	'histogram of durations taken to process /type requests in seconds',
-	{
-		buckets: latencyBuckets
-	})
-
-metrics.describe.histogram(metricNames.HTTP_ID_DURATION,
-	'histogram of durations taken to process /id requests in seconds',
-	{
-		buckets: latencyBuckets
-	})
-
-metrics.describe.histogram(metricNames.HTTP_SLUG_DURATION,
-	'histogram of durations taken to process /slug requests in seconds',
-	{
-		buckets: latencyBuckets
-	})
-
-metrics.describe.histogram(metricNames.HTTP_WHOAMI_DURATION,
-	'histogram of durations taken to process /whoami requests in seconds',
-	{
-		buckets: latencyBuckets
-	})
-
-metrics.describe.histogram(metricNames.MIRROR_DURATION,
-	'histogram of durations taken to make mirror calls in seconds',
-	{
-		buckets: latencyBuckets
-	})
-
-metrics.describe.histogram(metricNames.TRANSLATE_DURATION,
-	'histogram of durations taken to run translate calls in seconds',
-	{
-		buckets: latencyBuckets
-	})
-
-metrics.describe.histogram(metricNames.WORKER_JOB_DURATION,
-	'histogram of durations taken to complete worker jobs in seconds',
-	{
-		buckets: latencyBuckets
-	})
-
-metrics.describe.histogram(metricNames.SQL_GEN_DURATION,
-	'histogram of durations taken to generate sql with jsonschema2sql',
-	{
-		buckets: queryLatencyBuckets
-	})
-
-metrics.describe.histogram(metricNames.QUERY_DURATION,
-	'histogram of durations taken to query the database',
-	{
-		buckets: queryLatencyBuckets
-	})
 
 /**
  * @summary Measure duration of a promise execution and add to metrics
@@ -188,7 +37,7 @@ const measureAsync = async (name, labels, fn) => {
 	const start = new Date()
 	const result = await fn()
 	const end = new Date()
-	const duration = exports.toSeconds(end.getTime() - start.getTime())
+	const duration = utils.toSeconds(end.getTime() - start.getTime())
 	metrics.histogram(name, duration, labels)
 	return result
 }
@@ -253,6 +102,7 @@ exports.initExpress = (context) => {
  * metrics.startServer(context, 9000)
  */
 exports.startServer = (context, port) => {
+	descriptions.describe()
 	const b64enc = Buffer.from(`monitor:${environment.metrics.token}`).toString('base64')
 	const isAuthorized = (req) => {
 		return req.get('Authorization') === `Basic ${b64enc}`
@@ -286,7 +136,7 @@ exports.markCardInsert = (card) => {
 	if (!isCard(card)) {
 		return
 	}
-	metrics.inc(metricNames.CARD_INSERT_TOTAL, 1, {
+	metrics.inc(descriptions.names.CARD_INSERT_TOTAL, 1, {
 		type: card.type.split('@')[0]
 	})
 }
@@ -304,7 +154,7 @@ exports.markCardUpsert = (card) => {
 	if (!isCard(card)) {
 		return
 	}
-	metrics.inc(metricNames.CARD_UPSERT_TOTAL, 1, {
+	metrics.inc(descriptions.names.CARD_UPSERT_TOTAL, 1, {
 		type: card.type.split('@')[0]
 	})
 }
@@ -322,7 +172,7 @@ exports.markCardReadFromDatabase = (card) => {
 	if (!isCard(card)) {
 		return
 	}
-	metrics.inc(metricNames.CARD_READ_TOTAL, 1, {
+	metrics.inc(descriptions.names.CARD_READ_TOTAL, 1, {
 		type: card.type.split('@')[0],
 		source: 'database'
 	})
@@ -341,7 +191,7 @@ exports.markCardReadFromCache = (card) => {
 	if (!isCard(card)) {
 		return
 	}
-	metrics.inc(metricNames.CARD_READ_TOTAL, 1, {
+	metrics.inc(descriptions.names.CARD_READ_TOTAL, 1, {
 		type: card.type.split('@')[0],
 		source: 'cache'
 	})
@@ -357,7 +207,7 @@ exports.markCardReadFromCache = (card) => {
  * metrics.markBackSync('front')
  */
 exports.markBackSync = (integration) => {
-	metrics.inc(metricNames.BACK_SYNC_CARD_TOTAL, 1, {
+	metrics.inc(descriptions.names.BACK_SYNC_CARD_TOTAL, 1, {
 		type: integration
 	})
 }
@@ -372,7 +222,7 @@ exports.markBackSync = (integration) => {
  * metrics.markActionRequest('action-create-card')
  */
 exports.markActionRequest = (action) => {
-	metrics.inc(metricNames.WORKER_ACTION_REQUEST_TOTAL, 1, {
+	metrics.inc(descriptions.names.WORKER_ACTION_REQUEST_TOTAL, 1, {
 		type: action
 	})
 }
@@ -385,7 +235,7 @@ exports.markActionRequest = (action) => {
  * metrics.markQueueConcurrency()
  */
 exports.markQueueConcurrency = () => {
-	metrics.gauge(metricNames.WORKER_CONCURRENCY, environment.queue.concurrency)
+	metrics.gauge(descriptions.names.WORKER_CONCURRENCY, environment.queue.concurrency)
 }
 
 /**
@@ -399,7 +249,7 @@ exports.markQueueConcurrency = () => {
  * metrics.markJobAdd('action-create-card', context.id)
  */
 exports.markJobAdd = (action, id) => {
-	metrics.inc(metricNames.WORKER_SATURATION, 1, {
+	metrics.inc(descriptions.names.WORKER_SATURATION, 1, {
 		type: action,
 		worker: id
 	})
@@ -423,9 +273,9 @@ exports.markJobDone = (action, id, timestamp) => {
 		type: action,
 		worker: id
 	}
-	const duration = exports.toSeconds(new Date().getTime() - new Date(timestamp).getTime())
-	metrics.histogram(metricNames.WORKER_JOB_DURATION, duration, labels)
-	metrics.dec(metricNames.WORKER_SATURATION, 1, labels)
+	const duration = utils.toSeconds(new Date().getTime() - new Date(timestamp).getTime())
+	metrics.histogram(descriptions.names.WORKER_JOB_DURATION, duration, labels)
+	metrics.dec(descriptions.names.WORKER_SATURATION, 1, labels)
 }
 
 /**
@@ -443,9 +293,9 @@ exports.measureMirror = async (integration, fn) => {
 	const labels = {
 		type: integration
 	}
-	metrics.inc(metricNames.MIRROR_TOTAL, 1, labels)
-	const result = await measureAsync(metricNames.MIRROR_DURATION, labels, fn).catch((err) => {
-		metrics.inc(metricNames.MIRROR_FAILURE_TOTAL, 1, labels)
+	metrics.inc(descriptions.names.MIRROR_TOTAL, 1, labels)
+	const result = await measureAsync(descriptions.names.MIRROR_DURATION, labels, fn).catch((err) => {
+		metrics.inc(descriptions.names.MIRROR_FAILURE_TOTAL, 1, labels)
 		throw err
 	})
 	return result
@@ -466,8 +316,8 @@ exports.measureTranslate = async (integration, fn) => {
 	const labels = {
 		type: integration
 	}
-	metrics.inc(metricNames.TRANSLATE_TOTAL, 1, labels)
-	const results = await measureAsync(metricNames.TRANSLATE_DURATION, labels, fn)
+	metrics.inc(descriptions.names.TRANSLATE_TOTAL, 1, labels)
+	const results = await measureAsync(descriptions.names.TRANSLATE_DURATION, labels, fn)
 	return results
 }
 
@@ -484,9 +334,9 @@ const getAsyncMeasureFn = (prefix) => {
 		const total = `${prefix}_TOTAL`
 		const duration = `${prefix}_DURATION`
 		const failure = `${prefix}_FAILURE`
-		metrics.inc(metricNames[total], 1)
-		const result = await measureAsync(metricNames[duration], {}, fn).catch((err) => {
-			metrics.inc(metricNames[failure], 1)
+		metrics.inc(descriptions.names[total], 1)
+		const result = await measureAsync(descriptions.names[duration], {}, fn).catch((err) => {
+			metrics.inc(descriptions.names[failure], 1)
 			throw err
 		})
 		return result
@@ -554,7 +404,7 @@ exports.measureHttpWhoami = getAsyncMeasureFn('HTTP_WHOAMI')
  * @param {Number} ms - number of milliseconds it took to generate the query
  */
 exports.markSqlGenTime = (ms) => {
-	metrics.histogram(metricNames.SQL_GEN_DURATION, exports.toSeconds(ms))
+	metrics.histogram(descriptions.names.SQL_GEN_DURATION, utils.toSeconds(ms))
 }
 
 /**
@@ -564,7 +414,7 @@ exports.markSqlGenTime = (ms) => {
  * @param {Number} ms - number of milliseconds it took to execute the query
  */
 exports.markQueryTime = (ms) => {
-	metrics.histogram(metricNames.QUERY_DURATION, exports.toSeconds(ms))
+	metrics.histogram(descriptions.names.QUERY_DURATION, utils.toSeconds(ms))
 }
 
 /**
@@ -578,7 +428,7 @@ exports.markQueryTime = (ms) => {
  * metrics.markStreamOpened(context, 'cards')
  */
 exports.markStreamOpened = (context, table) => {
-	metrics.inc(metricNames.STREAMS_SATURATION, 1, {
+	metrics.inc(descriptions.names.STREAMS_SATURATION, 1, {
 		actor: actorFromContext(context),
 		table
 	})
@@ -595,7 +445,7 @@ exports.markStreamOpened = (context, table) => {
  * metrics.markStreamClosed(context, 'cards')
  */
 exports.markStreamClosed = (context, table) => {
-	metrics.dec(metricNames.STREAMS_SATURATION, 1, {
+	metrics.dec(descriptions.names.STREAMS_SATURATION, 1, {
 		actor: actorFromContext(context),
 		table
 	})
@@ -613,7 +463,7 @@ exports.markStreamClosed = (context, table) => {
  * metrics.markStreamLinkQuery(context, change)
  */
 exports.markStreamLinkQuery = (context, table, change) => {
-	metrics.inc(metricNames.STREAMS_LINK_QUERY_TOTAL, 1, {
+	metrics.inc(descriptions.names.STREAMS_LINK_QUERY_TOTAL, 1, {
 		table,
 		actor: actorFromContext(context),
 		type: (_.has(change, [ 'type' ]) && _.isString(change.type)) ? change.type.toLowerCase() : 'unknown',
@@ -632,7 +482,7 @@ exports.markStreamLinkQuery = (context, table, change) => {
  * metrics.markStreamError()
  */
 exports.markStreamError = (context, table) => {
-	metrics.inc(metricNames.STREAMS_ERROR_TOTAL, 1, {
+	metrics.inc(descriptions.names.STREAMS_ERROR_TOTAL, 1, {
 		actor: actorFromContext(context),
 		table
 	})

--- a/lib/index.spec.js
+++ b/lib/index.spec.js
@@ -46,11 +46,6 @@ const getMetrics = async (port) => {
 	})
 }
 
-ava('.toSeconds() should convert milliseconds to seconds', (test) => {
-	const seconds = metrics.toSeconds(3500)
-	test.is(seconds, 3.5)
-})
-
 ava('.initExpress() creates an express app', (test) => {
 	const app = metrics.initExpress(context)
 	test.truthy(app)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+/**
+ * A module that gathers and exposes Prometheus metrics.
+ *
+ * @module metrics
+ */
+
+/**
+ * @summary Convert milliseconds to seconds
+ * @function
+ *
+ * @param {Number} ms - milliseconds
+ * @returns {Number} seconds with fixed point notation of 4
+ *
+ * @example
+ * const seconds = toSeconds(ms)
+ */
+exports.toSeconds = (ms) => {
+	return Number((ms / 1000).toFixed(4))
+}

--- a/lib/utils.spec.js
+++ b/lib/utils.spec.js
@@ -1,0 +1,13 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+const ava = require('ava')
+const utils = require('./utils')
+
+ava('.toSeconds() should convert milliseconds to seconds', (test) => {
+	const seconds = utils.toSeconds(3500)
+	test.is(seconds, 3.5)
+})


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Improve the way metric names and descriptions are set, breaking things out to separate files.
Also adding checks that metrics haven't already been described before attempting to describe them, `node-metrics-gatherer` throws an error when attempting to describe the same metric more than once.