### PR TITLE
Add npm and yarn configs for dependabot

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+always-auth=true
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+save-prefix ""


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Add `.npmrc` and `.yarnrc` to hopefully allow dependabot to update private npm packages