### PR TITLE
Add card patch metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A module that gathers and exposes Prometheus metrics.
 * [metrics](#module_metrics)
     * _static_
         * [.actorFromContext(context)](#module_metrics.actorFromContext) ⇒ <code>String</code>
-        * [.initExpress(context)](#module_metrics.initExpress) ⇒ <code>Object</code>
+        * [.initExpress()](#module_metrics.initExpress) ⇒ <code>Object</code>
         * [.startServer(context, port)](#module_metrics.startServer)
         * [.markCardInsert(card)](#module_metrics.markCardInsert)
         * [.markCardUpsert(card)](#module_metrics.markCardUpsert)
@@ -51,10 +51,11 @@ A module that gathers and exposes Prometheus metrics.
         * [.markStreamClosed(context, table)](#module_metrics.markStreamClosed)
         * [.markStreamLinkQuery(context, table, change)](#module_metrics.markStreamLinkQuery)
         * [.markStreamError(context, table)](#module_metrics.markStreamError)
+        * [.measureCardPatch(fn)](#module_metrics.measureCardPatch) ⇒ <code>Any</code>
     * _inner_
         * [~measureAsync(name, labels, fn)](#module_metrics..measureAsync) ⇒ <code>Any</code>
         * [~isCard(card)](#module_metrics..isCard) ⇒ <code>Boolean</code>
-        * [~getAsyncMeasureFn(prefix)](#module_metrics..getAsyncMeasureFn) ⇒ <code>Any</code>
+        * [~getAsyncMeasureFn(prefix, labels)](#module_metrics..getAsyncMeasureFn) ⇒ <code>Any</code>
 
 <a name="module_metrics.actorFromContext"></a>
 
@@ -73,15 +74,10 @@ const actorName = exports.actorFromContext(context)
 ```
 <a name="module_metrics.initExpress"></a>
 
-### metrics.initExpress(context) ⇒ <code>Object</code>
+### metrics.initExpress() ⇒ <code>Object</code>
 **Kind**: static method of [<code>metrics</code>](#module_metrics)  
 **Summary**: Create express app using metrics and expose data on /metrics  
 **Returns**: <code>Object</code> - express app  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| context | <code>Object</code> | execution context |
-
 **Example**  
 ```js
 const application = metrics.initExpress(context)
@@ -408,6 +404,21 @@ metrics.markStreamLinkQuery(context, 'cards', change)
 ```js
 metrics.markStreamError()
 ```
+<a name="module_metrics.measureCardPatch"></a>
+
+### metrics.measureCardPatch(fn) ⇒ <code>Any</code>
+**Kind**: static method of [<code>metrics</code>](#module_metrics)  
+**Summary**: Execute a card patch, marking duration and totals  
+**Returns**: <code>Any</code> - card patch result  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| fn | <code>Promise</code> | card patch function to execute |
+
+**Example**  
+```js
+const result = await metrics.measureCardPatch(fn)
+```
 <a name="module_metrics..measureAsync"></a>
 
 ### metrics~measureAsync(name, labels, fn) ⇒ <code>Any</code>
@@ -418,7 +429,7 @@ metrics.markStreamError()
 | Param | Type | Description |
 | --- | --- | --- |
 | name | <code>String</code> | metric name |
-| labels | <code>Object</code> \| <code>Undefined</code> | metric labels |
+| labels | <code>Object</code> \| <code>function</code> | metric labels object or callback that returns labels object |
 | fn | <code>Promise</code> | function to execute and measure |
 
 **Example**  
@@ -442,7 +453,7 @@ const result = isCard(card)
 ```
 <a name="module_metrics..getAsyncMeasureFn"></a>
 
-### metrics~getAsyncMeasureFn(prefix) ⇒ <code>Any</code>
+### metrics~getAsyncMeasureFn(prefix, labels) ⇒ <code>Any</code>
 **Kind**: inner method of [<code>metrics</code>](#module_metrics)  
 **Summary**: Generates a generic measurement wrapper for an async function, that
 tracks total calls, total failures and duration  
@@ -451,4 +462,5 @@ tracks total calls, total failures and duration
 | Param | Type | Description |
 | --- | --- | --- |
 | prefix | <code>String</code> | metric name prefix |
+| labels | <code>Object</code> \| <code>function</code> | metric labels object or callback that returns labels object |
 

--- a/lib/descriptions.js
+++ b/lib/descriptions.js
@@ -40,6 +40,9 @@ exports.names = {
 	TRANSLATE_TOTAL: 'jf_translate_total',
 	TRANSLATE_DURATION: 'jf_translate_duration_seconds',
 	TRANSLATE_FAILURE_TOTAL: 'jf_translate_failure_total',
+	CARD_PATCH_TOTAL: 'jf_card_patch_total',
+	CARD_PATCH_FAILURE_TOTAL: 'jf_card_patch_failure_total',
+	CARD_PATCH_DURATION: 'jf_card_patch_duration_seconds',
 
 	HTTP_QUERY_DURATION: 'jf_http_api_query_duration_seconds',
 	HTTP_TYPE_DURATION: 'jf_http_api_type_duration_seconds',
@@ -83,6 +86,14 @@ const counters = [
 	{
 		name: exports.names.CARD_READ_TOTAL,
 		description: 'number of cards read from database/cache'
+	},
+	{
+		name: exports.names.CARD_PATCH_TOTAL,
+		description: 'number of card patch requests'
+	},
+	{
+		name: exports.names.CARD_PATCH_FAILURE_TOTAL,
+		description: 'number of card patch failures'
 	},
 	{
 		name: exports.names.MIRROR_TOTAL,
@@ -238,6 +249,11 @@ const histograms = [
 		name: exports.names.QUERY_DURATION,
 		description: 'histogram of durations taken to query the database',
 		buckets: queryLatencyBuckets
+	},
+	{
+		name: exports.names.CARD_PATCH_DURATION,
+		description: 'histogram of durations taken to patch cards in seconds',
+		buckets: latencyBuckets
 	}
 ]
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -26,7 +26,7 @@ const utils = require('./utils')
  * @function
  *
  * @param {String} name - metric name
- * @param {Object|Undefined} labels - metric labels
+ * @param {Object|Function} labels - metric labels object or callback that returns labels object
  * @param {Promise} fn - function to execute and measure
  * @returns {Any} promise execution result
  *
@@ -38,7 +38,8 @@ const measureAsync = async (name, labels, fn) => {
 	const result = await fn()
 	const end = new Date()
 	const duration = utils.toSeconds(end.getTime() - start.getTime())
-	metrics.histogram(name, duration, labels)
+	const histogramLabels = (_.isFunction(labels)) ? labels(result) : labels
+	metrics.histogram(name, duration, histogramLabels)
 	return result
 }
 
@@ -80,12 +81,11 @@ exports.actorFromContext = (context) => {
  * @summary Create express app using metrics and expose data on /metrics
  * @function
  *
- * @param {Object} context - execution context
  * @returns {Object} express app
  * @example
  * const application = metrics.initExpress(context)
  */
-exports.initExpress = (context) => {
+exports.initExpress = () => {
 	return metrics.collectAPIMetrics(express())
 }
 
@@ -330,15 +330,16 @@ exports.measureTranslate = async (integration, fn) => {
  * @function
  *
  * @param {String} prefix - metric name prefix
+ * @param {Object|Function} labels - metric labels object or callback that returns labels object
  * @returns {Any} api result
  */
-const getAsyncMeasureFn = (prefix) => {
+const getAsyncMeasureFn = (prefix, labels = {}) => {
 	return async (fn) => {
 		const total = `${prefix}_TOTAL`
 		const duration = `${prefix}_DURATION`
 		const failure = `${prefix}_FAILURE_TOTAL`
 		metrics.inc(descriptions.names[total], 1)
-		const result = await measureAsync(descriptions.names[duration], {}, fn).catch((err) => {
+		const result = await measureAsync(descriptions.names[duration], labels, fn).catch((err) => {
 			metrics.inc(descriptions.names[failure], 1)
 			throw err
 		})
@@ -489,4 +490,23 @@ exports.markStreamError = (context, table) => {
 		actor: exports.actorFromContext(context),
 		table
 	})
+}
+
+/**
+ * @summary Execute a card patch, marking duration and totals
+ * @function
+ *
+ * @param {Promise} fn - card patch function to execute
+ * @returns {Any} card patch result
+ *
+ * @example
+ * const result = await metrics.measureCardPatch(fn)
+ */
+exports.measureCardPatch = async (fn) => {
+	const result = await getAsyncMeasureFn('CARD_PATCH', (card) => {
+		return {
+			type: card.type.split('@')[0]
+		}
+	})(fn)
+	return result
 }

--- a/lib/index.spec.js
+++ b/lib/index.spec.js
@@ -37,6 +37,9 @@ ava.before(async (test) => {
 		}
 	}
 	test.context.actor = metrics.actorFromContext(test.context.context)
+	test.context.cardPatchFunc = async () => {
+		return test.context.card
+	}
 
 	// Start metrics server
 	metrics.startServer(test.context.context, environment.metrics.ports.app)
@@ -64,6 +67,7 @@ ava.before(async (test) => {
 	await metrics.measureHttpSlug(test.context.func)
 	await metrics.measureHttpAction(test.context.func)
 	await metrics.measureHttpWhoami(test.context.func)
+	await metrics.measureCardPatch(test.context.cardPatchFunc)
 
 	// Failure counters
 	await test.throwsAsync(metrics.measureMirror(test.context.integration, test.context.failFunc))
@@ -74,6 +78,7 @@ ava.before(async (test) => {
 	await test.throwsAsync(metrics.measureHttpSlug(test.context.failFunc))
 	await test.throwsAsync(metrics.measureHttpAction(test.context.failFunc))
 	await test.throwsAsync(metrics.measureHttpWhoami(test.context.failFunc))
+	await test.throwsAsync(metrics.measureCardPatch(test.context.failFunc))
 })
 
 const getMetrics = async () => {
@@ -298,6 +303,13 @@ ava('.measureHttpWhoami() should increment counters', async (test) => {
 	test.truthy(result.body.includes('jf_http_whoami_query_duration_seconds_count 1'))
 })
 
+ava('.measureCardPatch() should increment counters', async (test) => {
+	const result = await getMetrics()
+	test.truthy(result.body.includes('jf_card_patch_total 2'))
+	test.truthy(result.body.includes('jf_card_patch_failure_total 1'))
+	test.truthy(result.body.includes(`jf_card_patch_duration_seconds_count{type="${test.context.cardType}"} 1`))
+})
+
 ava('jf_card_insert_total has a description', async (test) => {
 	const result = await getMetrics()
 	const desc = '# HELP jf_card_insert_total number of cards inserted'
@@ -307,6 +319,18 @@ ava('jf_card_insert_total has a description', async (test) => {
 ava('jf_card_upsert_total has a description', async (test) => {
 	const result = await getMetrics()
 	const desc = '# HELP jf_card_upsert_total number of cards upserted'
+	test.truthy(result.body.includes(desc))
+})
+
+ava('jf_card_patch_total has a description', async (test) => {
+	const result = await getMetrics()
+	const desc = '# HELP jf_card_patch_total number of card patch requests'
+	test.truthy(result.body.includes(desc))
+})
+
+ava('jf_card_patch_failure_total has a description', async (test) => {
+	const result = await getMetrics()
+	const desc = '# HELP jf_card_patch_failure_total number of card patch failures'
 	test.truthy(result.body.includes(desc))
 })
 


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Josh Bowling <josh@balena.io>

---

Add metrics for card patching:
- total number of card patches
- total number of card patch failures
- duration of card patches

Example output after running a few updates on support threads:
```
root@dd94c35a5ce6:/usr/src/jellyfish/apps/action-server# curl -s http://monitor:TEST@localhost:9000/metrics | grep patch
# HELP jf_card_patch_duration_seconds histogram of durations taken to patch cards in seconds
# TYPE jf_card_patch_duration_seconds histogram
jf_card_patch_duration_seconds_bucket{le="0.004",type="support-thread"} 0
jf_card_patch_duration_seconds_bucket{le="0.0057",type="support-thread"} 0
jf_card_patch_duration_seconds_bucket{le="0.008",type="support-thread"} 11
jf_card_patch_duration_seconds_bucket{le="0.0113",type="support-thread"} 14
jf_card_patch_duration_seconds_bucket{le="0.016",type="support-thread"} 16
jf_card_patch_duration_seconds_bucket{le="0.0226",type="support-thread"} 17
jf_card_patch_duration_seconds_bucket{le="0.032",type="support-thread"} 18
jf_card_patch_duration_seconds_bucket{le="0.0453",type="support-thread"} 18
jf_card_patch_duration_seconds_bucket{le="0.064",type="support-thread"} 18
jf_card_patch_duration_seconds_bucket{le="0.0905",type="support-thread"} 18
jf_card_patch_duration_seconds_bucket{le="0.128",type="support-thread"} 18
jf_card_patch_duration_seconds_bucket{le="0.181",type="support-thread"} 18
jf_card_patch_duration_seconds_bucket{le="0.256",type="support-thread"} 18
jf_card_patch_duration_seconds_bucket{le="0.362",type="support-thread"} 18
jf_card_patch_duration_seconds_bucket{le="0.512",type="support-thread"} 18
jf_card_patch_duration_seconds_bucket{le="0.7241",type="support-thread"} 18
jf_card_patch_duration_seconds_bucket{le="1.024",type="support-thread"} 18
jf_card_patch_duration_seconds_bucket{le="1.4482",type="support-thread"} 18
jf_card_patch_duration_seconds_bucket{le="2.048",type="support-thread"} 18
jf_card_patch_duration_seconds_bucket{le="2.8963",type="support-thread"} 18
jf_card_patch_duration_seconds_bucket{le="4.096",type="support-thread"} 18
jf_card_patch_duration_seconds_bucket{le="5.7926",type="support-thread"} 18
jf_card_patch_duration_seconds_bucket{le="8.192",type="support-thread"} 18
jf_card_patch_duration_seconds_bucket{le="11.5852",type="support-thread"} 18
jf_card_patch_duration_seconds_bucket{le="16.384",type="support-thread"} 18
jf_card_patch_duration_seconds_bucket{le="23.1705",type="support-thread"} 18
jf_card_patch_duration_seconds_bucket{le="32.768",type="support-thread"} 18
jf_card_patch_duration_seconds_bucket{le="46.341",type="support-thread"} 18
jf_card_patch_duration_seconds_bucket{le="+Inf",type="support-thread"} 18
jf_card_patch_duration_seconds_sum{type="support-thread"} 0.17700000000000005
jf_card_patch_duration_seconds_count{type="support-thread"} 18
# HELP jf_card_patch_total number of cards patched
# TYPE jf_card_patch_total counter
jf_card_patch_total{type="support-thread"} 18
```