### PR TITLE
Add README.md to git index in lint-staged

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "*.js": [
       "eslint --cache --fix",
       "npm run doc",
-      "git add"
+      "git add README.md"
     ]
   }
 }


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Only `git add` README.md as `lint-staged` automatically adds other files.