### PR TITLE
Handle missing type field on card partials

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -161,7 +161,7 @@ export function startServer(context: Context, port: number): Server {
  */
 export function markCardInsert(card: Contract): void {
 	metrics.inc(Names.card.insert.total, 1, {
-		type: card.type.split('@')[0],
+		type: utils.parseType(card),
 	});
 }
 
@@ -178,7 +178,7 @@ export function markCardInsert(card: Contract): void {
  */
 export function markCardUpsert(card: Contract): void {
 	metrics.inc(Names.card.upsert.total, 1, {
-		type: card.type.split('@')[0],
+		type: utils.parseType(card),
 	});
 }
 
@@ -193,9 +193,9 @@ export function markCardUpsert(card: Contract): void {
  * markCardReadFromDatabase(card);
  * ```
  */
-export function markCardReadFromDatabase(card: Contract): void {
+export function markCardReadFromDatabase(card: any): void {
 	metrics.inc(Names.card.read.total, 1, {
-		type: card.type.split('@')[0],
+		type: utils.parseType(card),
 		source: 'database',
 	});
 }
@@ -211,9 +211,9 @@ export function markCardReadFromDatabase(card: Contract): void {
  * markCardReadFromCache(card);
  * ```
  */
-export function markCardReadFromCache(card: Contract): void {
+export function markCardReadFromCache(card: any): void {
 	metrics.inc(Names.card.read.total, 1, {
-		type: card.type.split('@')[0],
+		type: utils.parseType(card),
 		source: 'cache',
 	});
 }
@@ -542,10 +542,7 @@ export function markStreamLinkQuery(
 			has(change, ['type']) && isString(change.type)
 				? change.type.toLowerCase()
 				: 'unknown',
-		card:
-			has(change, ['after', 'type']) && isString(change.after.type)
-				? change.after.type.split('@')[0]
-				: 'unknown',
+		card: has(change, ['after']) ? utils.parseType(change.after) : 'unknown',
 	});
 }
 
@@ -583,7 +580,7 @@ export function markStreamError(context: object, table: string): void {
 export async function measureCardPatch(fn: () => Promise<any>): Promise<any> {
 	const result = await getAsyncMeasureFn(Names.card.patch, (card: Contract) => {
 		return {
-			type: card.type.split('@')[0],
+			type: utils.parseType(card),
 		};
 	})(fn);
 	return result;

--- a/lib/utils.spec.ts
+++ b/lib/utils.spec.ts
@@ -12,3 +12,19 @@ describe('toSeconds()', () => {
 		expect(seconds).toBe(3.5);
 	});
 });
+
+describe('parseType()', () => {
+	test('should return a card type when available', () => {
+		const type = utils.parseType({
+			type: 'card@1.0.0',
+		});
+		expect(type).toEqual('card');
+	});
+
+	test('should return "unknown" when card type is unavailable', () => {
+		const type = utils.parseType({
+			data: {},
+		});
+		expect(type).toEqual('unknown');
+	});
+});

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,6 +4,9 @@
  * Proprietary and confidential.
  */
 
+import has from 'lodash/has';
+import isString from 'lodash/isString';
+
 /**
  * @summary Convert milliseconds to seconds
  * @function
@@ -18,4 +21,19 @@
  */
 export function toSeconds(ms: number): number {
 	return Number((ms / 1000).toFixed(4));
+}
+
+/**
+ * @summary Parse type from a card or card partial
+ * @function
+ *
+ * @param card - card or card partial object
+ * @returns card type or unkown if unavailable
+ */
+export function parseType(card: any): string {
+	const type =
+		has(card, ['type']) && isString(card.type)
+			? card.type.split('@')[0]
+			: 'unknown';
+	return type;
 }


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

On backend `query()` calls, the results being passed to metrics may not be full cards. This means we cannot assume `type` is defined.