### PR TITLE
Clean up types, rename card to contract

### DIFF
--- a/lib/descriptions.ts
+++ b/lib/descriptions.ts
@@ -1,5 +1,10 @@
 import { metrics } from '@balena/node-metrics-gatherer';
-import { Histogram, MeasureMetricNames, Metric, MetricNames } from './types';
+import type {
+	Histogram,
+	MeasureMetricNames,
+	Metric,
+	MetricNames,
+} from './types';
 import * as utils from './utils';
 
 /**
@@ -44,7 +49,7 @@ const queryLatencyBuckets = metrics.client
  * List of names for all defined metrics
  */
 export const Names: MetricNames = {
-	card: {
+	contract: {
 		upsert: {
 			total: 'jf_card_upsert_total',
 		},
@@ -95,24 +100,24 @@ export const Names: MetricNames = {
  */
 const counters: Metric[] = [
 	{
-		name: Names.card.upsert.total,
-		description: 'number of cards upserted',
+		name: Names.contract.upsert.total,
+		description: 'number of contracts upserted',
 	},
 	{
-		name: Names.card.insert.total,
-		description: 'number of cards inserted',
+		name: Names.contract.insert.total,
+		description: 'number of contracts inserted',
 	},
 	{
-		name: Names.card.read.total,
-		description: 'number of cards read from database/cache',
+		name: Names.contract.read.total,
+		description: 'number of contracts read from database/cache',
 	},
 	{
-		name: Names.card.patch.total,
-		description: 'number of card patch requests',
+		name: Names.contract.patch.total,
+		description: 'number of contract patch requests',
 	},
 	{
-		name: Names.card.patch.failureTotal,
-		description: 'number of card patch failures',
+		name: Names.contract.patch.failureTotal,
+		description: 'number of contract patch failures',
 	},
 	{
 		name: Names.mirror.total,
@@ -283,8 +288,8 @@ const histograms: Histogram[] = [
 		buckets: queryLatencyBuckets,
 	},
 	{
-		name: Names.card.patch.durationSeconds,
-		description: 'histogram of durations taken to patch cards in seconds',
+		name: Names.contract.patch.durationSeconds,
+		description: 'histogram of durations taken to patch contracts in seconds',
 		buckets: latencyBuckets,
 	},
 ];

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,4 +1,4 @@
-import { Contract } from '@balena/jellyfish-types/build/core';
+import type { Contract } from '@balena/jellyfish-types/build/core';
 
 /**
  * Common metric definition
@@ -29,9 +29,9 @@ export interface MetricName {
 }
 
 /**
- * Card operation metric names
+ * Contract operation metric names
  */
-export interface CardMetricNames extends Pick<MetricName, 'total'> {}
+export interface ContractMetricNames extends Pick<MetricName, 'total'> {}
 
 /**
  * Worker metric names
@@ -68,10 +68,10 @@ export interface MeasureMetricNames
  * Definition of full list of metric names
  */
 export interface MetricNames {
-	card: {
-		upsert: CardMetricNames;
-		insert: CardMetricNames;
-		read: CardMetricNames;
+	contract: {
+		upsert: ContractMetricNames;
+		insert: ContractMetricNames;
+		read: ContractMetricNames;
 		patch: MeasureMetricNames;
 	};
 	worker: WorkerMetricNames;
@@ -97,10 +97,4 @@ export interface StreamChange {
 	type: string;
 	before: Contract;
 	after: Contract;
-}
-
-// TS-TODO: Replace with proper Context type
-export interface Context {
-	id: string;
-	[key: string]: any;
 }

--- a/lib/utils.spec.ts
+++ b/lib/utils.spec.ts
@@ -6,19 +6,3 @@ describe('toSeconds()', () => {
 		expect(seconds).toBe(3.5);
 	});
 });
-
-describe('parseType()', () => {
-	test('should return a card type when available', () => {
-		const type = utils.parseType({
-			type: 'card@1.0.0',
-		});
-		expect(type).toEqual('card');
-	});
-
-	test('should return "unknown" when card type is unavailable', () => {
-		const type = utils.parseType({
-			data: {},
-		});
-		expect(type).toEqual('unknown');
-	});
-});

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,5 +1,4 @@
-import has from 'lodash/has';
-import isString from 'lodash/isString';
+import _ from 'lodash';
 
 /**
  * @summary Convert milliseconds to seconds
@@ -15,19 +14,4 @@ import isString from 'lodash/isString';
  */
 export function toSeconds(ms: number): number {
 	return Number((ms / 1000).toFixed(4));
-}
-
-/**
- * @summary Parse type from a card or card partial
- * @function
- *
- * @param card - card or card partial object
- * @returns card type or unkown if unavailable
- */
-export function parseType(card: any): string {
-	const type =
-		has(card, ['type']) && isString(card.type)
-			? card.type.split('@')[0]
-			: 'unknown';
-	return type;
 }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "devDependencies": {
     "@balena/jellyfish-config": "^2.0.1",
-    "@balena/jellyfish-types": "^1.2.3",
+    "@balena/jellyfish-types": "^2.0.0",
     "@balena/lint": "^6.2.0",
     "@types/express": "^4.17.13",
     "@types/jest": "^27.0.3",


### PR DESCRIPTION
Switch from internally defined Context to LogContext.
Stop deep importing lodash.
Rename card/cards to contract/contracts.

Change-type: major
Signed-off-by: Josh Bowling <josh@balena.io>