### PR TITLE
Use latest version of jellyfish-logger

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@balena/jellyfish-environment": "^6.0.14",
-    "@balena/jellyfish-logger": "^4.0.27",
+    "@balena/jellyfish-logger": "^5.0.0",
     "@balena/node-metrics-gatherer": "^5.7.5",
     "express": "^4.17.2",
     "lodash": "^4.17.21"


### PR DESCRIPTION
This major version of the logger no longer handles uncaught exceptions, which would result in mangled and unreadable log messages.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>