### PR TITLE
Change engines to >=16 to enable node 18 tests/usage

### DIFF
--- a/lib/index.spec.ts
+++ b/lib/index.spec.ts
@@ -167,7 +167,7 @@ async function getMetrics(): Promise<{
 }> {
 	return new Promise((resolve, reject) => {
 		const options = {
-			hostname: 'localhost',
+			hostname: '127.0.0.1',
 			port: defaultEnvironment.metrics.ports.app,
 			path: '/metrics',
 			auth: `monitor:${defaultEnvironment.metrics.token}`,

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/product-os/jellyfish-metrics.git"
   },
   "engines": {
-    "node": "^16.0.0"
+    "node": ">=16.0.0"
   },
   "description": "Metrics library for Jellyfish",
   "main": "build/index.js",


### PR DESCRIPTION
Change-type: patch